### PR TITLE
Update grunt-download-atom-shell

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -2,7 +2,7 @@
   "name": "hello-atom-build",
   "version": "0.1.0",
   "devDependencies": {
-    "grunt": "^0.4.4",
-    "grunt-download-atom-shell": "^0.7.0"
+    "grunt": "^0.4.5",
+    "grunt-download-atom-shell": "^0.8.2"
   }
 }


### PR DESCRIPTION
The example is broken due to older versions of `grunt` and `grunt-download-atom-shell`
